### PR TITLE
Fix thread cache hit rate default warn/crit values.

### DIFF
--- a/pack/commands.cfg
+++ b/pack/commands.cfg
@@ -114,6 +114,6 @@ define command {
 
 define command {
        command_name     check_mysql_threadcache_hitrate
-       command_line     $PLUGINSDIR$/check_mysql_health --hostname $HOSTADDRESS$ --username $_HOSTMYSQLUSER$ --password $_HOSTMYSQLPASSWORD$ --mode threadcache-hitrate --warning $_HOSTTHREADCACHE_WARN$ --critical $_HOSTTHREADCACHE_CRIT$
+       command_line     $PLUGINSDIR$/check_mysql_health --hostname $HOSTADDRESS$ --username $_HOSTMYSQLUSER$ --password $_HOSTMYSQLPASSWORD$ --mode threadcache-hitrate --warning $_HOSTTHREADCACHEHITRATE_WARN$ --critical $_HOSTTHREADCACHEHITRATE_CRIT$
 }
 

--- a/pack/templates.cfg
+++ b/pack/templates.cfg
@@ -42,8 +42,8 @@ define host{
    _LONGRUNNINGPROCS_CRIT    20
    _OPENFILES_WARN           80
    _OPENFILES_CRIT           95
-   _THREADCACHE_WARN         10
-   _THREADCACHE_CRIT         20
+   _THREADCACHEHITRATE_WARN         99:
+   _THREADCACHEHITRATE_CRIT         95:
 }
 
 define host{


### PR DESCRIPTION
Regarding this article hit rate should be as close to 100% as possible.
http://www.epigroove.com/blog/optimize-mysql-the-thread-cache

This patch change default critical and warning value to 95: and 99:
I changed macro name in order to be more consistent with other macro name.
