### PR TITLE
Add mysql-cluster host type

### DIFF
--- a/pack/discovery.cfg
+++ b/pack/discovery.cfg
@@ -4,3 +4,10 @@ define discoveryrule {
        openports                ^3306$
        +use                     mysql
 }
+
+define discoveryrule {
+       discoveryrule_name       Mysql-Cluster
+       creation_type            host
+       openports                ^1186$
+       +use                     mysql-cluster
+}

--- a/pack/services/cluster_ndb_running.cfg
+++ b/pack/services/cluster_ndb_running.cfg
@@ -2,6 +2,6 @@ define service{
    service_description           Mysql-cluster-ndbd-running
    use            mysql-service
    register       0
-   host_name	  mysql
+   host_name	    mysql-cluster
    check_command  check_mysql_cluster_ndbd_running
 }

--- a/pack/templates.cfg
+++ b/pack/templates.cfg
@@ -60,7 +60,11 @@ define host{
    _SLAVELAG_CRIT 20
 }
 
-
+define host{
+   name           mysql-cluster
+   use            generic-mysql
+   register       0
+}
 
 define service{
   name				mysql-service

--- a/pack/templates.cfg
+++ b/pack/templates.cfg
@@ -1,11 +1,17 @@
 # DATABASES HOSTS
 define host{
-   name           mysql
+   name           generic-mysql
    use            generic-host
    register       0
 
    _MYSQLUSER                $MYSQLUSER$
    _MYSQLPASSWORD            $MYSQLPASSWORD$
+}
+
+define host{
+   name           mysql
+   use            generic-mysql
+   register       0
 
    # The plugin need a ":" sign when perfdata should be greater than the thresholds.
    _UPTIME_WARN		      10:
@@ -48,7 +54,7 @@ define host{
 
 define host{
    name           mysql-slave
-   use            generic-host
+   use            generic-mysql
    register       0
    _SLAVELAG_WARN 10
    _SLAVELAG_CRIT 20


### PR DESCRIPTION
If mysql cluster isn't install the check_mysql_cluster_ndbd_running command will never work.
Here this check will be proceed only for 'mysql-cluster' tagged host.
